### PR TITLE
Persist the display of Jade.

### DIFF
--- a/src/main/java/me/justahuman/slimefun_essentials/SlimefunEssentials.java
+++ b/src/main/java/me/justahuman/slimefun_essentials/SlimefunEssentials.java
@@ -29,6 +29,7 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class SlimefunEssentials implements ClientModInitializer {
     @Override
@@ -84,8 +85,14 @@ public class SlimefunEssentials implements ClientModInitializer {
 
                 ResourceLoader.addPlacedBlock(payload.pos(), payload.id().toLowerCase());
             });
+            // on join, load placed blocks
+            ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> ResourceLoader.loadPlacedBlocks(Objects.requireNonNull(handler.getServerInfo()).address));
 
-            ClientPlayConnectionEvents.DISCONNECT.register((handler, minecraftClient) -> ResourceLoader.clearPlacedBlocks());
+            // on disconnect, save placed blocks and clear the map
+            ClientPlayConnectionEvents.DISCONNECT.register((handler, minecraftClient) -> {
+                ResourceLoader.savePlacedBlocks(Objects.requireNonNull(handler.getServerInfo()).address);
+                ResourceLoader.clearPlacedBlocks();
+            });
         }
 
         if (ModConfig.autoToggleAddons()) {


### PR DESCRIPTION
When leaving the server, store placedBlocks in a file. Upon joining the server, load the corresponding file based on the address. This way, placedBlocks achieves persistent storage. Even after restarting the game, Jade can correctly display previously placed blocks.
I conducted tests on a 1.20.6 Paper server using the localized Chinese version of SlimeFun, so I'm not sure if this issue exists in the original SlimeFun.